### PR TITLE
Add support for running on Nitrous

### DIFF
--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your rails-devise project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start rails-devise via "Run > Start Rails Devise"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/README.textile
+++ b/README.textile
@@ -77,7 +77,7 @@ h2. Getting the Application
 
 h3. Local
 
-You have several options for getting the code on your own machine. You can _fork_, _clone_, or _generate_.
+You have several options for getting the code on your own machine. You can _fork_, _clone_, _generate_ or use _nitrous.io_.
 
 h4. Fork
 
@@ -92,6 +92,14 @@ $ git clone git://github.com/RailsApps/rails-devise.git
 </pre>
 
 You'll need "git":http://git-scm.com/ on your machine. See "Rails and Git":http://railsapps.github.io/rails-git.html.
+
+h4. Nitrous Quickstart
+
+If you don't want to go through the hassle of installing things on your personal machine, you can quickly create a free rails-devise development environment in the cloud on Nitrous:
+
+!{width:142px; height: 34px}https://nitrous-image-icons.s3.amazonaws.com/quickstart.png(Nitrous Quickstart)!:https://www.nitrous.io/quickstart
+
+In the IDE, start Rails Devise via `Run > Start Rails Devise` and access your site via `Preview > 3000`.
 
 h4. Generate
 

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "rails",
+  "ports": [3000],
+  "name": "Rails Devise",
+  "description": "Rails 4.2 starter app with Devise for authentication.",
+  "scripts": {
+    "post-create": "rm -rf ~/code/example && rbenv install 2.2.3 && rbenv global 2.2.3 && gem install bundler && cd ~/code/rails-devise && bundle install && rake db:migrate && rake db:test:prepare",
+    "Start Rails Devise": "cd ~/code/rails-devise && rails s -b 0.0.0.0"
+  }
+}


### PR DESCRIPTION
This PR adds support for quickly getting the rails-devise example app running on [Nitrous](https://www.nitrous.io). We're calling it [Nitrous Quickstarts](https://community.nitrous.io/posts/nitrous-quickstarts) (which is just a "marketing" name) and it basically provides an easy way to run apps without requiring developers to install anything locally.

Whether this PR gets merged or not, I'm featuring rails-devise on [this page](https://www.nitrous.io/quickstarts/) because I think it's a great use case for Nitrous Quickstarts :smile_cat: 
