### PR TITLE
Update devise_permitted_parameters.rb

### DIFF
--- a/config/initializers/devise_permitted_parameters.rb
+++ b/config/initializers/devise_permitted_parameters.rb
@@ -8,8 +8,8 @@ module DevisePermittedParameters
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up) << :name
-    devise_parameter_sanitizer.for(:account_update) << :name
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
 
 end


### PR DESCRIPTION
The "for" syntax is deprecated, using new "permit" syntax.