### PR TITLE
Update devise.rb

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'no-reply@' + Rails.application.secrets.domain_name
+  config.mailer_sender = 'no-reply@' + Rails.application.secrets.domain_name.to_s # fix for Issue #11
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
Fix for issue #11 where
`config.mailer_sender = 'no-reply@' + Rails.application.secrets.domain_name`  
results in the following error 
`no implicit conversion of nil into String (TypeError)`