### PR TITLE
Disable mailer locally to avoid errors

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = true
   # Send email in development mode?
-  config.action_mailer.perform_deliveries = true
+  config.action_mailer.perform_deliveries = false
 
 
   # Suppress logger output for asset requests.


### PR DESCRIPTION
Disable mailer locally to avoid [`Net::SMTPAuthenticationError` when resetting password](https://github.com/RailsApps/rails-devise/issues/27).

Although this is admittedly trivial, having the app work as-is will prevent confusion for devs new to Rails.