### PR TITLE
Update schema so it's in sync with the repo

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150101170206) do
+ActiveRecord::Schema.define(version: 20140224203311) do
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -27,9 +26,8 @@ ActiveRecord::Schema.define(version: 20150101170206) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "name"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end


### PR DESCRIPTION
Fix #29 by running `rake db:migrate`.

Although this is admittedly trivial, having the `schema.rb` in sync with the repo will prevent confusion for devs new to Rails.